### PR TITLE
Use Todoist's Sync API v9

### DIFF
--- a/lib/nin/integration/todoist/client.rb
+++ b/lib/nin/integration/todoist/client.rb
@@ -2,7 +2,7 @@ module Nin
   module Integration
     module Todoist
       class Client
-        BASE_URI = 'https://api.todoist.com/sync/v8'.freeze
+        BASE_URI = 'https://api.todoist.com/sync/v9'.freeze
 
         def initialize(token)
           @token = token


### PR DESCRIPTION
v8 was deprecated on December 5, 2022.

I didn't notice any other incompatibility, but here's the migration guide from v8: https://developer.todoist.com/sync/v9/#migrating-from-v8